### PR TITLE
Wizard: Improved reliability and clearer system checks

### DIFF
--- a/be-bop-wizard/be-bop-wizard.sh
+++ b/be-bop-wizard/be-bop-wizard.sh
@@ -46,7 +46,7 @@
 # The “wizard” part is simply automation done with a bit of common sense.
 set -eEuo pipefail
 
-readonly SCRIPT_VERSION="2.3.5"
+readonly SCRIPT_VERSION="2.3.6"
 readonly SCRIPT_NAME="be-bop-wizard"
 readonly SESSION_ID="wizard-$(date +%s)-$$"
 
@@ -954,7 +954,7 @@ die_unsupported_os_distribution_for_tasks() {
     local distro_name="${DETECTED_HUMAN_OS_DISTRIBUTION:-}"
     local comment=""
     if ! has_fact systemd_operational; then
-        comment="(systemd not operational)"
+        comment="(without systemd)"
     fi
 
     local task_descriptions=()


### PR DESCRIPTION
The installation wizard now handles more system configurations smoothly. It checks whether your CPU supports AVX (required for MongoDB), waits for be-BOP to fully start before moving to the next step, and handles non-systemd systems with clearer messages. System readiness detection is also more forgiving and robust, and connection timeouts have been slightly increased for better reliability during setup.

Closes #9 and #10.