### PR TITLE
🦋 Add SSE proxy configuration to nginx for real-time sync

### DIFF
--- a/be-bop-bootstrap/be-bop-cli.sh
+++ b/be-bop-bootstrap/be-bop-cli.sh
@@ -8,7 +8,7 @@
 
 set -eEuo pipefail
 
-readonly SCRIPT_VERSION="2.5.10"
+readonly SCRIPT_VERSION="2.5.11"
 readonly SCRIPT_NAME="be-bop-cli"
 readonly EXIT_SUCCESS=0
 readonly EXIT_ERROR=1

--- a/be-bop-bootstrap/be-bop-wizard.sh
+++ b/be-bop-bootstrap/be-bop-wizard.sh
@@ -46,7 +46,7 @@
 # The “wizard” part is simply automation done with a bit of common sense.
 set -eEuo pipefail
 
-readonly SCRIPT_VERSION="2.5.10"
+readonly SCRIPT_VERSION="2.5.11"
 readonly SCRIPT_NAME="be-bop-wizard"
 readonly SESSION_ID="wizard-$(date +%s)-$$"
 
@@ -2118,6 +2118,19 @@ server {
 
     proxy_set_header "Connection" "";
 
+    # SSE endpoints - long-lived connections for real-time sync
+    location ~ /sse$ {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Host $http_host;
+    }
+
     location / {
         proxy_pass http://localhost:3000;
         proxy_set_header Host $host;
@@ -2198,6 +2211,19 @@ server {
     ssl_stapling on;
     ssl_stapling_verify on;
     proxy_set_header "Connection" "";
+
+    # SSE endpoints - long-lived connections for real-time sync
+    location ~ /sse$ {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Host $http_host;
+    }
 
     location / {
         proxy_pass http://localhost:3000;


### PR DESCRIPTION
be-BOP's new collaborative sync feature uses Server-Sent Events which require long-lived connections. Without dedicated nginx proxy settings, SSE connections may be buffered or timed out.

Existing installations will pick up the new config on next wizard run via fingerprint change detection.

Fixes #38